### PR TITLE
Update ND_AGENTS to also include the previous default services

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ services:
     environment:
       - ND_PLUGINS_ENABLED=true
       - ND_PLUGINS_AUTORELOAD=true
-      - ND_AGENTS=audiomuseai
+      - ND_AGENTS=audiomuseai,lastfm,spotify,deezer
     volumes:
       - ./data:/data
       - /path/to/music:/music:ro


### PR DESCRIPTION
If you only set ND_agents=audiomuseai it will break other functionalities that are enabled by default (artist bios from lastfm, artist coverart etc)

Agents configuration is respected by navidrome in order of priority. 
Setting Agents to "audiomuseai,lastfm,spotify,deezer", navidrome will still use audiomuseai for the getSimilarSongsByTrack and getSimilarSongsByArtist, but will also use lastfm/spotify/deezer for other agent functionality.

Since "lastfm,spotify,deezer" is the navidrome-default, i think this is the better default recommendation for people to not break these other functionalities.