### PR TITLE
feat: implement GetSimilarArtists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PACKAGE_NAME := audiomuseai
 .PHONY: build package clean
 
 build:
-	tinygo build -o $(PLUGIN_NAME).wasm -target=wasip1 -scheduler=none -buildmode=c-shared main.go
+	tinygo build -o $(PLUGIN_NAME).wasm -target=wasip1 -scheduler=none -buildmode=c-shared .
 
 package: build
 	# Navidrome expects the wasm file in the package to be named `plugin.wasm`

--- a/audiomuse_api.go
+++ b/audiomuse_api.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+
+	"github.com/navidrome/navidrome/plugins/pdk/go/pdk"
+)
+
+type SimilarArtistsResponse struct {
+	Artist           string `json:"artist"`
+	ArtistID         string `json:"artist_id"`
+	ComponentMatches []struct {
+		Artist1RepresentativeSongs []struct {
+			ItemID string `json:"item_id"`
+			Title  string `json:"title"`
+		} `json:"artist1_representative_songs"`
+		Artist2RepresentativeSongs []struct {
+			ItemID string `json:"item_id"`
+			Title  string `json:"title"`
+		} `json:"artist2_representative_songs"`
+	} `json:"component_matches"`
+}
+
+func getSimilarArtists(id string, includeComponentMatches bool) ([]SimilarArtistsResponse, error) {
+	apiBaseURL := getConfigString(configAPIUrl, defaultAPIUrl)
+	artistCount := getConfigInt("artistSimilarCount", defaultArtistSimilarCount)
+
+	params := url.Values{}
+	params.Set("artist", id)
+	params.Set("n", strconv.Itoa(artistCount))
+	params.Set("include_component_matches", strconv.FormatBool(includeComponentMatches))
+
+	apiURL := fmt.Sprintf("%s/api/similar_artists?%s", apiBaseURL, params.Encode())
+	pdk.Log(pdk.LogInfo, fmt.Sprintf("[AudioMuse] Calling GetSimilarArtists API for artist ID %s: %s", id, apiURL))
+
+	req := pdk.NewHTTPRequest(pdk.MethodGet, apiURL)
+	resp := req.Send()
+
+	pdk.Log(pdk.LogInfo, fmt.Sprintf("[AudioMuse] API response status: %d", resp.Status()))
+	if resp.Status() != 200 {
+		errMsg := fmt.Sprintf("[AudioMuse] ERROR: AudioMuse-AI returned status %d", resp.Status())
+		pdk.Log(pdk.LogError, errMsg)
+		return nil, fmt.Errorf("AudioMuse-AI returned status %d", resp.Status())
+	}
+
+	var artists []SimilarArtistsResponse
+
+	body := resp.Body()
+	if err := json.Unmarshal(body, &artists); err != nil {
+		errMsg := fmt.Sprintf("[AudioMuse] ERROR: Failed to parse artist response: %v", err)
+		pdk.Log(pdk.LogError, errMsg)
+		return nil, fmt.Errorf("failed to parse AudioMuse-AI artist response: %w", err)
+	}
+
+	pdk.Log(pdk.LogInfo, fmt.Sprintf("[AudioMuse] Successfully parsed %d similar artists", len(artists)))
+
+	return artists, nil
+}


### PR DESCRIPTION
This change implements the GetSimilarArtists method on Audiomuse plugin to provide related artists from Audiomuse to navidrome. The implementation is very similar to GetSimilarSongsByArtist, so I took the liberty to factorize common code in a new file: `audiomuse_api.go` and updated the Makefile to work with multiple files.

This change was tested with the Feishin 2 player and I could validate that the related artists indeed came from Audiomuse.
In some cases however Feishin showed different artists from what Audiomuse returns. The logs indicate that the plugin was indeed called and everything was successful, so I'm not sure what the issue is. Perhaps some caching from before the plugin was added on Navidrome ? Any help appreciated, I'm new to this ecosystem. 

Note:
The `audiomuseai.ndp` file is tracked in the repository. I wasn't sure if this is intentional so I did not include the updated version in this PR. I can push it if needed.