### PR TITLE
fix: use request track count, better mix artist similar songs

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -15,14 +15,6 @@
           "description": "Base URL for the AudioMuse-AI server (e.g., http://192.168.3.203:8000).",
           "default": "http://192.168.3.203:8000"
         },
-        "trackCount": {
-          "type": "integer",
-          "title": "Number of Similar Tracks",
-          "description": "Maximum number of similar tracks to return. Default: 200",
-          "default": 200,
-          "minimum": 10,
-          "maximum": 500
-        },
         "artistSimilarCount": {
           "type": "integer",
           "title": "Number of Similar Artists",
@@ -63,10 +55,6 @@
           "label": "Song Instant Mix",
           "elements": [
             {
-              "type": "Control",
-              "scope": "#/properties/trackCount"
-            },
-            {
               "type": "HorizontalLayout",
               "elements": [
                 {
@@ -100,7 +88,9 @@
     },
     "http": {
       "reason": "To call AudioMuse-AI API for similar tracks",
-      "requiredHosts": ["*"]
+      "requiredHosts": [
+        "*"
+      ]
     }
   }
 }


### PR DESCRIPTION
The plugin used a config value for the track count to return for GetSimilarSongsByTrack, and returned everything for GetSimilarSongsByArtist. This ignores the "count" parameter in the request, which indicates how many songs the player wants.

This change makes use of this parameter and removes the plugin config value to better match what navidrome expects, and have one less thing for users to configure / worry about.

For GetSimilarSongsByTrack we simply use the parameter from the query and keep the same logic.

For GetSimilarSongsByArtist, however, no limit was implemented. Before this change the plugin returned tracks in "clumps": a few tracks for artist1, a few tracks for artist2, etc. I changed the logic to instead alternate between the "base artist" (from the request) and related artists, stopping when we have the desired number of tracks. This IMHO better emulates the "radio" features of popular streaming services.