### PR TITLE
Update manifest.json to use website tag with correct link

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "AudioMuse-AI Instant Mix",
   "id": "audiomuseai",
   "author": "AudioMuse",
-  "homepage": "https://github.com/yourusername/audiomuse-navidrome-plugin",
+  "website": "https://github.com/NeptuneHub/AudioMuse-AI-NV-plugin",
   "version": "1.0.0",
   "description": "Replaces the Instant Mix button with AudioMuse-AI recommendations for similar tracks",
   "config": {


### PR DESCRIPTION
Just a small fix to the manifest.json so the github link shows up on the plugins page so you can quickly navigate to see if there is a new version. Based this off of the default Apple Music plugin's manifest.json: https://github.com/navidrome/apple-music-plugin/blob/main/manifest.json