### PR TITLE
Update README.md removing spotify

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ services:
     environment:
       - ND_PLUGINS_ENABLED=true
       - ND_PLUGINS_AUTORELOAD=true
-      - ND_AGENTS=audiomuseai,lastfm,spotify,deezer
+      - ND_AGENTS=audiomuseai,lastfm,deezer
       - ND_DEVARTISTINFOTIMETOLIVE=1s
     volumes:
       - ./data:/data


### PR DESCRIPTION
Spotify is not supported anymore, but I also didn't want to add Apple Music, as a separate plugin is required that might not be installed. See https://github.com/navidrome/navidrome/pull/5197
There may be a variant for usage with the config in navidrome.toml. Requiring the user to add:
```toml
Plugins.Enabled=true
Plugins.AutoReload=true
Agents="audiomuseai,deezer,lastfm"
DevArtistInfoTimeToLive="1s"
```
DevArtistInfoTimeToLive can also be set in the toml: https://github.com/navidrome/navidrome/blob/master/conf/configuration.go#L140