### PR TITLE
Add configurable shuffle for track-based similar songsFeat/shuffle similar songs option

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"net/url"
 	"slices"
 	"strconv"
@@ -19,6 +20,7 @@ const (
 	configAPIToken            = "apiToken"
 	configEliminateDuplicates = "eliminateDuplicates"
 	configRadiusSimilarity    = "radiusSimilarity"
+	configShuffleBeforeAdd    = "shuffleBeforeAdd"
 )
 
 // Default values
@@ -27,6 +29,7 @@ const (
 	defaultArtistSimilarCount  = 10
 	defaultEliminateDuplicates = true
 	defaultRadiusSimilarity    = true
+	defaultShuffleBeforeAdd    = false
 )
 
 // Compile-time check that we implement necessary interfaces
@@ -85,6 +88,16 @@ func getConfigBool(key string, defaultValue bool) bool {
 	return defaultValue
 }
 
+func shuffleSongs(songs []metadata.SongRef) {
+	if len(songs) < 2 {
+		return
+	}
+
+	rand.Shuffle(len(songs), func(i, j int) {
+		songs[i], songs[j] = songs[j], songs[i]
+	})
+}
+
 // authHeaders returns a headers map with a Bearer token if configured, or nil otherwise.
 func authHeaders() map[string]string {
 	if token := getConfigString(configAPIToken, ""); token != "" {
@@ -112,6 +125,10 @@ func (p *audioMusePlugin) GetSimilarSongsByTrack(input metadata.SimilarSongsByTr
 			Artist: track.Author,
 			Album:  track.Album,
 		})
+	}
+
+	if getConfigBool(configShuffleBeforeAdd, defaultShuffleBeforeAdd) {
+		shuffleSongs(songs)
 	}
 
 	pdk.Log(pdk.LogInfo, fmt.Sprintf("[AudioMuse] Returning %d songs to Navidrome", len(songs)))

--- a/manifest.json
+++ b/manifest.json
@@ -39,6 +39,12 @@
           "title": "Use Radius Similarity",
           "description": "Use radius-based similarity algorithm. Default: true",
           "default": true
+        },
+        "shuffleBeforeAdd": {
+          "type": "boolean",
+          "title": "Shuffle Before Add",
+          "description": "Shuffle similar songs before returning them to Instant Mix. Default: false",
+          "default": false
         }
       }
     },
@@ -76,6 +82,10 @@
                 {
                   "type": "Control",
                   "scope": "#/properties/radiusSimilarity"
+                },
+                {
+                  "type": "Control",
+                  "scope": "#/properties/shuffleBeforeAdd"
                 }
               ]
             }


### PR DESCRIPTION
This PR adds a new optional setting, `shuffleBeforeAdd`, to shuffle similar songs before they are returned for Instant Mix.

The shuffle is applied only in `GetSimilarSongsByTrack`, because that is the place where a randomized order makes sense. Other flows keep their current behavior:
- `GetSonicSimilarTracks`
- `FindSonicPath`
- `GetSimilarSongsByArtist`

The option is exposed in `manifest.json` and defaults to `false`, so existing behavior is unchanged unless the setting is enabled.

## Manual test
- enabled `shuffleBeforeAdd` and confirmed that Instant Mix returns songs in a different order
- disabled `shuffleBeforeAdd` and confirmed that the original order is preserved
- checked that the new option appears in the plugin configuration UI
- verified that artist-related and sonic path behavior is unchanged