### PR TITLE
fix(artists): deduplicate similar artists in GetSimilarArtists

### DIFF
--- a/main.go
+++ b/main.go
@@ -353,7 +353,16 @@ func (p *audioMusePlugin) GetSimilarArtists(input metadata.SimilarArtistsRequest
 		Artists: make([]metadata.ArtistRef, 0, len(artists)),
 	}
 
+	seen := make(map[string]bool)
 	for _, a := range artists {
+		if a.ArtistID == "" {
+			continue
+		}
+		if seen[a.ArtistID] {
+			continue
+		}
+		seen[a.ArtistID] = true
+
 		res.Artists = append(res.Artists, metadata.ArtistRef{
 			ID:   a.ArtistID,
 			Name: a.Artist,

--- a/main.go
+++ b/main.go
@@ -358,6 +358,9 @@ func (p *audioMusePlugin) GetSimilarArtists(input metadata.SimilarArtistsRequest
 		if a.ArtistID == "" {
 			continue
 		}
+		if a.ArtistID == input.ID {
+			continue
+		}
 		if seen[a.ArtistID] {
 			continue
 		}


### PR DESCRIPTION
I noticed that when viewing similar artists for some artists, the same artist
would appear more than once, in one case "Black Eyed Peas" appeared 5 times.
This behavior didn't happen without the plugin installed.

I confirmed this is not a database issue: the repeated entries in the
`getArtistInfo.view` response have identical IDs, meaning AudioMuse-AI is
returning the same artist object multiple times, not separate duplicates.

I believe the duplicates are already coming from AudioMuse-AI, so this fix
is only at the plugin level and does not address the root cause.

The fix follows the same `seen`/`continue` pattern already used in
`GetSimilarSongsByArtist`.

## Tests

Captured `getArtistInfo.view` responses before and after the fix, attached below.

**Before** (10 entries, duplicates present):
<details>
<summary>getArtistInfo_before.jsonc</summary>

```jsonc
// POST /rest/getArtistInfo.view HTTP/1.1
// Host: [REDACTED]
// User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:152.0) Gecko/20100101 Firefox/152.0
// Accept: application/json, text/plain, */*
// Accept-Language: en-US,en;q=0.9
// Accept-Encoding: gzip, deflate, br, zstd
// Content-Type: application/x-www-form-urlencoded
// Content-Length: 114
// Origin: https://[REDACTED]
// Sec-GPC: 1
// Connection: keep-alive
// Referer: https://[REDACTED]/feishin/
// Cookie: [REDACTED]
// Sec-Fetch-Dest: empty
// Sec-Fetch-Mode: cors
// Sec-Fetch-Site: same-origin
// Pragma: no-cache
// Cache-Control: no-cache
{
  "subsonic-response": {
    "status": "ok",
    "version": "1.16.1",
    "type": "navidrome",
    "serverVersion": "0.63.2 (be10f89c)",
    "openSubsonic": true,
    "artistInfo": {
      "biography": "Hailing from The Netherlands, a country rich with electronic artists, Bakermat stands out thanks to his mix of jazzy saxophones, rock guitars, tropical percussion, and soulful vocals.  • Music runs in the Dutchman’s blood. His mother was an opera singer, and his father raised him on American jazz, soul, and funk records. • Bakermat’s 2012 breakout single “Vandaag” (translation: “One Day”) samples Martin Luther King, Jr.’s famous 1963 “I Have a Dream” speech. The song charted in 14 countries and went platinum in Germany. • Since his music is rooted in organic sounds, Bakermat performs alongside a full band, mixing his productions with live sax, guitar, and vocals.",
      "lastFmUrl": "https://music.apple.com/us/artist/-/537398578",
      "smallImageUrl": "https://[REDACTED]/share/img/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFyLTNLcWNKajhlUWN3czkybWxReXdkb0RfMCIsImlzcyI6Ik5EIn0.iq8AQD1etR3KZQClqVLz-mXd9hcKdWnj81Jm9li7IuQ?size=300",
      "mediumImageUrl": "https://[REDACTED]/share/img/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFyLTNLcWNKajhlUWN3czkybWxReXdkb0RfMCIsImlzcyI6Ik5EIn0.iq8AQD1etR3KZQClqVLz-mXd9hcKdWnj81Jm9li7IuQ?size=600",
      "largeImageUrl": "https://[REDACTED]/share/img/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFyLTNLcWNKajhlUWN3czkybWxReXdkb0RfMCIsImlzcyI6Ik5EIn0.iq8AQD1etR3KZQClqVLz-mXd9hcKdWnj81Jm9li7IuQ?size=1200",
      "similarArtist": [
        {
          "id": "0QHmeQTzFOkLX7cCOV0KBg",
          "name": "Black Eyed Peas",
          "coverArt": "ar-0QHmeQTzFOkLX7cCOV0KBg_0",
          "artistImageUrl": "https://[REDACTED]/share/img/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFyLTBRSG1lUVR6Rk9rTFg3Y0NPVjBLQmdfMCIsImlzcyI6Ik5EIn0.SqXBVKTsJ-eIlZI70Jz2bIJT5wtcaRG4o3n2Ar-_6yc?size=600"
        },
        {
          "id": "0KIbvSK5oXBIK1cJ9kwURm",
          "name": "Dennis Lloyd",
          "coverArt": "ar-0KIbvSK5oXBIK1cJ9kwURm_0",
          "artistImageUrl": "https://[REDACTED]/share/img/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFyLTBLSWJ2U0s1b1hCSUsxY0o5a3dVUm1fMCIsImlzcyI6Ik5EIn0.MtDnwFaIuo8T4c9Pypp1DMLe9kUrQjodYJ-MgjamEWs?size=600"
        },
        {
          "id": "0QHmeQTzFOkLX7cCOV0KBg",
          "name": "Black Eyed Peas",
          "coverArt": "ar-0QHmeQTzFOkLX7cCOV0KBg_0",
          "artistImageUrl": "https://[REDACTED]/share/img/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFyLTBRSG1lUVR6Rk9rTFg3Y0NPVjBLQmdfMCIsImlzcyI6Ik5EIn0.SqXBVKTsJ-eIlZI70Jz2bIJT5wtcaRG4o3n2Ar-_6yc?size=600"
        },
        {
          "id": "2Jh7meve7KUVyDufDQODkb",
          "name": "Teto",
          "coverArt": "ar-2Jh7meve7KUVyDufDQODkb_0",
          "artistImageUrl": "https://[REDACTED]/share/img/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFyLTJKaDdtZXZlN0tVVnlEdWZEUU9Ea2JfMCIsImlzcyI6Ik5EIn0.uNI79rQK-GQ8V6uiMvHJUyekW9AYYZnxabWm-V3zbBg?size=600"
        },
        {
          "id": "0QHmeQTzFOkLX7cCOV0KBg",
          "name": "Black Eyed Peas",
          "coverArt": "ar-0QHmeQTzFOkLX7cCOV0KBg_0",
          "artistImageUrl": "https://[REDACTED]/share/img/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFyLTBRSG1lUVR6Rk9rTFg3Y0NPVjBLQmdfMCIsImlzcyI6Ik5EIn0.SqXBVKTsJ-eIlZI70Jz2bIJT5wtcaRG4o3n2Ar-_6yc?size=600"
        },
        {
          "id": "2Jh7meve7KUVyDufDQODkb",
          "name": "Teto",
          "coverArt": "ar-2Jh7meve7KUVyDufDQODkb_0",
          "artistImageUrl": "https://[REDACTED]/share/img/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFyLTJKaDdtZXZlN0tVVnlEdWZEUU9Ea2JfMCIsImlzcyI6Ik5EIn0.uNI79rQK-GQ8V6uiMvHJUyekW9AYYZnxabWm-V3zbBg?size=600"
        },
        {
          "id": "0QHmeQTzFOkLX7cCOV0KBg",
          "name": "Black Eyed Peas",
          "coverArt": "ar-0QHmeQTzFOkLX7cCOV0KBg_0",
          "artistImageUrl": "https://[REDACTED]/share/img/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFyLTBRSG1lUVR6Rk9rTFg3Y0NPVjBLQmdfMCIsImlzcyI6Ik5EIn0.SqXBVKTsJ-eIlZI70Jz2bIJT5wtcaRG4o3n2Ar-_6yc?size=600"
        },
        {
          "id": "0QHmeQTzFOkLX7cCOV0KBg",
          "name": "Black Eyed Peas",
          "coverArt": "ar-0QHmeQTzFOkLX7cCOV0KBg_0",
          "artistImageUrl": "https://[REDACTED]/share/img/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFyLTBRSG1lUVR6Rk9rTFg3Y0NPVjBLQmdfMCIsImlzcyI6Ik5EIn0.SqXBVKTsJ-eIlZI70Jz2bIJT5wtcaRG4o3n2Ar-_6yc?size=600"
        },
        {
          "id": "3ULPbnnQr5qtcIczHYJzfc",
          "name": "Coaley",
          "coverArt": "ar-3ULPbnnQr5qtcIczHYJzfc_0",
          "artistImageUrl": "https://[REDACTED]/share/img/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFyLTNVTFBibm5RcjVxdGNJY3pIWUp6ZmNfMCIsImlzcyI6Ik5EIn0.epZU9s0kSHGVwT3bpZ04kX31E47cXrVeZG2O-_5EtZw?size=600"
        },
        {
          "id": "0ZGjf7AIXkeMMwqdFTBRDl",
          "name": "Lil Wayne",
          "coverArt": "ar-0ZGjf7AIXkeMMwqdFTBRDl_0",
          "artistImageUrl": "https://[REDACTED]/share/img/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFyLTBaR2pmN0FJWGtlTU13cWRGVEJSRGxfMCIsImlzcyI6Ik5EIn0.xL8aBj-AOJ88_w3dQgGDf1pfQD_dT7uy91hX4TGQ7ew?size=600"
        }
      ]
    }
  }
}
```

</details>

**After** (5 unique entries, no duplicates):
<details>
<summary>getArtistInfo_after.jsonc</summary>

```jsonc
// POST /rest/getArtistInfo.view HTTP/1.1
// Host: [REDACTED]
// User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:152.0) Gecko/20100101 Firefox/152.0
// Accept: application/json, text/plain, */*
// Accept-Language: en-US,en;q=0.9
// Accept-Encoding: gzip, deflate, br, zstd
// Content-Type: application/x-www-form-urlencoded
// Content-Length: 114
// Origin: https://[REDACTED]
// Sec-GPC: 1
// Connection: keep-alive
// Referer: https://[REDACTED]/feishin/
// Cookie: [REDACTED]
// Sec-Fetch-Dest: empty
// Sec-Fetch-Mode: cors
// Sec-Fetch-Site: same-origin
{
  "subsonic-response": {
    "status": "ok",
    "version": "1.16.1",
    "type": "navidrome",
    "serverVersion": "0.63.2 (be10f89c)",
    "openSubsonic": true,
    "artistInfo": {
      "biography": "Hailing from The Netherlands, a country rich with electronic artists, Bakermat stands out thanks to his mix of jazzy saxophones, rock guitars, tropical percussion, and soulful vocals.  • Music runs in the Dutchman’s blood. His mother was an opera singer, and his father raised him on American jazz, soul, and funk records. • Bakermat’s 2012 breakout single “Vandaag” (translation: “One Day”) samples Martin Luther King, Jr.’s famous 1963 “I Have a Dream” speech. The song charted in 14 countries and went platinum in Germany. • Since his music is rooted in organic sounds, Bakermat performs alongside a full band, mixing his productions with live sax, guitar, and vocals.",
      "lastFmUrl": "https://music.apple.com/us/artist/-/537398578",
      "smallImageUrl": "https://[REDACTED]/share/img/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFyLTNLcWNKajhlUWN3czkybWxReXdkb0RfMCIsImlzcyI6Ik5EIn0.iq8AQD1etR3KZQClqVLz-mXd9hcKdWnj81Jm9li7IuQ?size=300",
      "mediumImageUrl": "https://[REDACTED]/share/img/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFyLTNLcWNKajhlUWN3czkybWxReXdkb0RfMCIsImlzcyI6Ik5EIn0.iq8AQD1etR3KZQClqVLz-mXd9hcKdWnj81Jm9li7IuQ?size=600",
      "largeImageUrl": "https://[REDACTED]/share/img/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFyLTNLcWNKajhlUWN3czkybWxReXdkb0RfMCIsImlzcyI6Ik5EIn0.iq8AQD1etR3KZQClqVLz-mXd9hcKdWnj81Jm9li7IuQ?size=1200",
      "similarArtist": [
        {
          "id": "0QHmeQTzFOkLX7cCOV0KBg",
          "name": "Black Eyed Peas",
          "coverArt": "ar-0QHmeQTzFOkLX7cCOV0KBg_0",
          "artistImageUrl": "https://[REDACTED]/share/img/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFyLTBRSG1lUVR6Rk9rTFg3Y0NPVjBLQmdfMCIsImlzcyI6Ik5EIn0.SqXBVKTsJ-eIlZI70Jz2bIJT5wtcaRG4o3n2Ar-_6yc?size=600"
        },
        {
          "id": "0KIbvSK5oXBIK1cJ9kwURm",
          "name": "Dennis Lloyd",
          "coverArt": "ar-0KIbvSK5oXBIK1cJ9kwURm_0",
          "artistImageUrl": "https://[REDACTED]/share/img/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFyLTBLSWJ2U0s1b1hCSUsxY0o5a3dVUm1fMCIsImlzcyI6Ik5EIn0.MtDnwFaIuo8T4c9Pypp1DMLe9kUrQjodYJ-MgjamEWs?size=600"
        },
        {
          "id": "2Jh7meve7KUVyDufDQODkb",
          "name": "Teto",
          "coverArt": "ar-2Jh7meve7KUVyDufDQODkb_0",
          "artistImageUrl": "https://[REDACTED]/share/img/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFyLTJKaDdtZXZlN0tVVnlEdWZEUU9Ea2JfMCIsImlzcyI6Ik5EIn0.uNI79rQK-GQ8V6uiMvHJUyekW9AYYZnxabWm-V3zbBg?size=600"
        },
        {
          "id": "3ULPbnnQr5qtcIczHYJzfc",
          "name": "Coaley",
          "coverArt": "ar-3ULPbnnQr5qtcIczHYJzfc_0",
          "artistImageUrl": "https://[REDACTED]/share/img/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFyLTNVTFBibm5RcjVxdGNJY3pIWUp6ZmNfMCIsImlzcyI6Ik5EIn0.epZU9s0kSHGVwT3bpZ04kX31E47cXrVeZG2O-_5EtZw?size=600"
        },
        {
          "id": "0ZGjf7AIXkeMMwqdFTBRDl",
          "name": "Lil Wayne",
          "coverArt": "ar-0ZGjf7AIXkeMMwqdFTBRDl_0",
          "artistImageUrl": "https://[REDACTED]/share/img/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFyLTBaR2pmN0FJWGtlTU13cWRGVEJSRGxfMCIsImlzcyI6Ik5EIn0.xL8aBj-AOJ88_w3dQgGDf1pfQD_dT7uy91hX4TGQ7ew?size=600"
        }
      ]
    }
  }
}
```

</details>